### PR TITLE
Implement log-location feature 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,11 @@ readme = "README.md"
 default = ["panic-quiet"]
 # Makes failed unwraps panic with an empty message.
 panic-quiet = []
+# Includes caller location in the tracing event
+log-location = []
 
 [dependencies]
 tracing = { version = "0.1", default-features = false }
+
+[dev-dependencies]
+tracing-test = { version = "0.2.3", features = ["no-env-filter"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,6 +271,19 @@ impl<T> OptionExt<T> for Option<T> {
 #[cold]
 #[track_caller]
 fn failed(msg: &str) -> ! {
+    #[cfg(feature = "log-location")]
+    {
+        let location = std::panic::Location::caller();
+        tracing::error!(
+            unwrap.filepath = location.file(),
+            unwrap.lineno = location.line(),
+            unwrap.columnno = location.column(),
+            "{}",
+            msg
+        );
+    }
+
+    #[cfg(not(feature = "log-location"))]
     tracing::error!("{}", msg);
 
     #[cfg(feature = "panic-quiet")]
@@ -283,6 +296,20 @@ fn failed(msg: &str) -> ! {
 #[cold]
 #[track_caller]
 fn failed_with(msg: &str, value: &dyn fmt::Debug) -> ! {
+    #[cfg(feature = "log-location")]
+    {
+        let location = std::panic::Location::caller();
+        tracing::error!(
+            unwrap.filepath = location.file(),
+            unwrap.lineno = location.line(),
+            unwrap.columnno = location.column(),
+            "{}: {:?}",
+            msg,
+            &value
+        );
+    }
+
+    #[cfg(not(feature = "log-location"))]
     tracing::error!("{}: {:?}", msg, &value);
 
     #[cfg(feature = "panic-quiet")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,6 +219,8 @@ pub trait OptionExt<T> {
 }
 
 impl<T> OptionExt<T> for Option<T> {
+    #[inline]
+    #[track_caller]
     fn unwrap_or_log(self) -> T {
         match self {
             Some(val) => val,

--- a/tests/log-location.rs
+++ b/tests/log-location.rs
@@ -1,0 +1,15 @@
+use tracing_unwrap::OptionExt;
+
+#[test]
+#[tracing_test::traced_test]
+#[cfg_attr(not(feature = "log-location"), ignore)]
+fn log_location() {
+    let _ = std::panic::catch_unwind(|| {
+        Option::<()>::None.unwrap_or_log();
+        // Note: if you change anything above here, make sure to adjust the asserts below as well
+    });
+
+    assert!(logs_contain("unwrap.filepath=\"tests/log-location.rs\""));
+    assert!(logs_contain("unwrap.lineno=8"));
+    assert!(logs_contain("unwrap.columnno=28"));
+}


### PR DESCRIPTION
tracing uses the `file!()` and `line!()` macros to determine the location where a log message was generated. Unfortunately, `#[track_caller]` does not affect the value of these macros. Hence, using the errors logged by tracing-unwrap always point to tracing-unwrap's `failed` and `failed_with` functions instead of the location where unwrap was called.

The `log-location` feature uses `std::panic::Location::caller()` to look up the correct location and include it in the error event.